### PR TITLE
Calculate expressions

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -3,6 +3,7 @@ package ledger
 import (
 	"bufio"
 	"fmt"
+	"github.com/marcmak/calc/calc"
 	"io"
 	"math/big"
 	"sort"
@@ -54,8 +55,7 @@ func ParseLedger(ledgerReader io.Reader) (generalLedger []*Transaction, err erro
 				}
 			}
 			lastIndex := len(nonEmptyWords) - 1
-			rationalNum := new(big.Rat)
-			_, balErr := rationalNum.SetString(nonEmptyWords[lastIndex])
+			balErr, rationalNum := getBalance(nonEmptyWords[lastIndex])
 			if balErr == false {
 				// Assuming no balance and whole line is account name
 				accChange.Name = strings.Join(nonEmptyWords, " ")
@@ -78,6 +78,16 @@ func ParseLedger(ledgerReader io.Reader) (generalLedger []*Transaction, err erro
 	}
 	sort.Sort(sortTransactionsByDate{generalLedger})
 	return generalLedger, scanner.Err()
+}
+
+func getBalance(balance string) (bool, *big.Rat) {
+	rationalNum := new(big.Rat)
+	if strings.Contains(balance, "(") {
+		rationalNum.SetFloat64(calc.Solve(balance))
+		return true, rationalNum
+	}
+	_, isValid := rationalNum.SetString(balance)
+	return isValid, rationalNum
 }
 
 // Takes a transaction and balances it. This is mainly to fill in the empty part

--- a/parse.go
+++ b/parse.go
@@ -47,7 +47,9 @@ func ParseLedger(ledgerReader io.Reader) (generalLedger []*Transaction, err erro
 			trans = &Transaction{Payee: payeeString, Date: transDate}
 		} else {
 			var accChange Account
-			lineSplit := strings.Split(line, " ")
+			// remove heading and tailing space from the line
+			line = strings.Trim(line, " \t")
+			lineSplit := strings.Split(line, "  ")
 			nonEmptyWords := []string{}
 			for _, word := range lineSplit {
 				if len(word) > 0 {

--- a/parse.go
+++ b/parse.go
@@ -11,6 +11,10 @@ import (
 	"time"
 )
 
+const (
+	WHITESPACE = " \t"
+)
+
 // Parses a ledger file and returns a list of Transactions.
 //
 // Transactions are sorted by date.
@@ -48,7 +52,7 @@ func ParseLedger(ledgerReader io.Reader) (generalLedger []*Transaction, err erro
 		} else {
 			var accChange Account
 			// remove heading and tailing space from the line
-			line = strings.Trim(line, " \t")
+			line = strings.Trim(line, WHITESPACE)
 			lineSplit := strings.Split(line, "  ")
 			nonEmptyWords := []string{}
 			for _, word := range lineSplit {
@@ -57,7 +61,7 @@ func ParseLedger(ledgerReader io.Reader) (generalLedger []*Transaction, err erro
 				}
 			}
 			lastIndex := len(nonEmptyWords) - 1
-			balErr, rationalNum := getBalance(nonEmptyWords[lastIndex])
+			balErr, rationalNum := getBalance(strings.Trim(nonEmptyWords[lastIndex], WHITESPACE))
 			if balErr == false {
 				// Assuming no balance and whole line is account name
 				accChange.Name = strings.Join(nonEmptyWords, " ")

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,0 +1,56 @@
+package ledger
+
+import (
+	"bytes"
+	"encoding/json"
+	"math/big"
+	"testing"
+	"time"
+)
+
+type testCase struct {
+	data         string
+	transactions []*Transaction
+	err          error
+}
+
+var testCases = []testCase{
+	testCase{
+		`1970/01/01 Payee
+	Expense/test  (123 * 3)
+	Assets
+`,
+		[]*Transaction{
+			&Transaction{
+				Payee: "Payee",
+				Date:  time.Unix(0, 0).UTC(),
+				AccountChanges: []Account{
+					Account{
+						"Expense/test",
+						big.NewRat(369.0, 1),
+					},
+					Account{
+						"Assets",
+						big.NewRat(-369.0, 1),
+					},
+				},
+			},
+		},
+		nil,
+	},
+}
+
+func TestParseLedger(t *testing.T) {
+	for _, tc := range testCases {
+		b := bytes.NewBufferString(tc.data)
+		transactions, err := ParseLedger(b)
+		if err != tc.err {
+			t.Errorf("Error: expected `%s`, got `%s`", tc.err, err)
+		}
+		exp, _ := json.Marshal(tc.transactions)
+		got, _ := json.Marshal(transactions)
+		if string(exp) != string(got) {
+			t.Errorf("Error: expected \n`%s`, \ngot \n`%s`", exp, got)
+		}
+	}
+}


### PR DESCRIPTION
Ledger supports Expression amounts (http://www.ledger-cli.org/3.0/doc/ledger3.html#Expression-amounts) in parenthesis. This change uses the `calc` package to evaluate the expressions and return the numeric result.

Also added a test case for the change