### PR TITLE
Small fixes

### DIFF
--- a/cmd/ledger/print.go
+++ b/cmd/ledger/print.go
@@ -56,7 +56,7 @@ func PrintBalances(accountList []*ledger.Account, printZeroBalances bool, depth,
 	}
 	fmt.Println(strings.Repeat("-", columns))
 	outBalanceString := overallBalance.FloatString(ledger.DisplayPrecision)
-	spaceCount := columns - len(outBalanceString)
+	spaceCount := columns - utf8.RuneCountInString(outBalanceString)
 	fmt.Printf("%s%s\n", strings.Repeat(" ", spaceCount), outBalanceString)
 }
 
@@ -65,7 +65,7 @@ func PrintTransaction(trans *ledger.Transaction, columns int) {
 	fmt.Printf("%s %s\n", trans.Date.Format(ledger.TransactionDateFormat), trans.Payee)
 	for _, accChange := range trans.AccountChanges {
 		outBalanceString := accChange.Balance.FloatString(ledger.DisplayPrecision)
-		spaceCount := columns - 4 - len(accChange.Name) - len(outBalanceString)
+		spaceCount := columns - 4 - utf8.RuneCountInString(accChange.Name) - utf8.RuneCountInString(outBalanceString)
 		fmt.Printf("    %s%s%s\n", accChange.Name, strings.Repeat(" ", spaceCount), outBalanceString)
 	}
 	fmt.Println("")

--- a/parse.go
+++ b/parse.go
@@ -26,10 +26,11 @@ func ParseLedger(ledgerReader io.Reader) (generalLedger []*Transaction, err erro
 	var lineCount int
 	for scanner.Scan() {
 		line = scanner.Text()
+		trimmedLine := strings.Trim(line, whitespace)
 		lineCount++
 		if strings.HasPrefix(line, ";") {
 			// nop
-		} else if len(line) == 0 {
+		} else if len(trimmedLine) == 0 {
 			if trans != nil {
 				transErr := balanceTransaction(trans)
 				if transErr != nil {
@@ -53,8 +54,7 @@ func ParseLedger(ledgerReader io.Reader) (generalLedger []*Transaction, err erro
 		} else {
 			var accChange Account
 			// remove heading and tailing space from the line
-			line = strings.Trim(line, whitespace)
-			lineSplit := strings.Split(line, "  ")
+			lineSplit := strings.Split(trimmedLine, "  ")
 			nonEmptyWords := []string{}
 			for _, word := range lineSplit {
 				if len(word) > 0 {

--- a/parse.go
+++ b/parse.go
@@ -26,6 +26,7 @@ func ParseLedger(ledgerReader io.Reader) (generalLedger []*Transaction, err erro
 	var lineCount int
 	for scanner.Scan() {
 		line = scanner.Text()
+		// remove heading and tailing space from the line
 		trimmedLine := strings.Trim(line, whitespace)
 		lineCount++
 		if strings.HasPrefix(line, ";") {
@@ -53,7 +54,6 @@ func ParseLedger(ledgerReader io.Reader) (generalLedger []*Transaction, err erro
 			trans = &Transaction{Payee: payeeString, Date: transDate}
 		} else {
 			var accChange Account
-			// remove heading and tailing space from the line
 			lineSplit := strings.Split(trimmedLine, "  ")
 			nonEmptyWords := []string{}
 			for _, word := range lineSplit {


### PR DESCRIPTION
Two small fixes here:

- [x] Lines with whitespace caused the parser to panic
- [x] ledger print used `len` instead of `utf8.RuneCountInString`
