### PR TITLE
Skipping all comment lines

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -32,7 +32,7 @@ func ParseLedger(ledgerReader io.Reader) (generalLedger []*Transaction, err erro
 		// remove heading and tailing space from the line
 		trimmedLine := strings.Trim(line, whitespace)
 		lineCount++
-		if strings.HasPrefix(line, ";") {
+		if strings.HasPrefix(trimmedLine, ";") {
 			// nop
 		} else if len(trimmedLine) == 0 {
 			if trans != nil {

--- a/parse_test.go
+++ b/parse_test.go
@@ -119,6 +119,30 @@ var testCases = []testCase{
 		},
 		nil,
 	},
+	testCase{
+		`1970-01-01 Payee
+	Expense/test  123
+	; Expense/test  123
+	Assets
+`,
+		[]*Transaction{
+			&Transaction{
+				Payee: "Payee",
+				Date:  time.Unix(0, 0).UTC(),
+				AccountChanges: []Account{
+					Account{
+						"Expense/test",
+						big.NewRat(123.0, 1),
+					},
+					Account{
+						"Assets",
+						big.NewRat(-123.0, 1),
+					},
+				},
+			},
+		},
+		nil,
+	},
 }
 
 func TestParseLedger(t *testing.T) {


### PR DESCRIPTION
I have ledger files with comments in the body of the transaction.  This PR allows you to skip those comments.