### PR TITLE
Improve performance of ParseLedgerAsync

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -34,6 +34,8 @@ func ParseLedger(ledgerReader io.Reader) (generalLedger []*Transaction, err erro
 	}
 }
 
+var accountToAmountSpace = regexp.MustCompile(" {2,}|\t+")
+
 // ParseLedgerAsync parses a ledger file and returns a Transaction and error channels .
 //
 func ParseLedgerAsync(ledgerReader io.Reader) (c chan *Transaction, e chan error) {
@@ -47,7 +49,6 @@ func ParseLedgerAsync(ledgerReader io.Reader) (c chan *Transaction, e chan error
 		var line string
 		var lineCount int
 
-		accountToAmountSpace := regexp.MustCompile(" {2,}|\t+")
 		for scanner.Scan() {
 			line = scanner.Text()
 			// remove heading and tailing space from the line

--- a/parse_test.go
+++ b/parse_test.go
@@ -227,3 +227,34 @@ func TestParseLedger(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkParseLedger(b *testing.B) {
+	tc := testCase{
+		`1970/01/01 Payee
+	Expense/test  (123 * 3)
+	Assets
+`,
+		[]*Transaction{
+			&Transaction{
+				Payee: "Payee",
+				Date:  time.Unix(0, 0).UTC(),
+				AccountChanges: []Account{
+					Account{
+						"Expense/test",
+						big.NewRat(369.0, 1),
+					},
+					Account{
+						"Assets",
+						big.NewRat(-369.0, 1),
+					},
+				},
+			},
+		},
+		nil,
+	}
+
+	data := bytes.NewBufferString(tc.data)
+	for n := 0; n < b.N; n++ {
+		ParseLedger(data)
+	}
+}


### PR DESCRIPTION
This change significantly reduces the number of allocations during ledger parsing, requiring less garbage collection, and speeding up the application. As you can see below, this is approximately 3 times faster and performs 80% fewer allocations.

Before
------
go test -run=XXX -bench=. -benchmem ledger
goos: darwin
goarch: amd64
pkg: ledger
BenchmarkParseLedger-8   	 100000	     11386 ns/op	    6376 B/op	      29 allocs/op

After
-----
go test -run=XXX -bench=. -benchmem ledger
goos: darwin
goarch: amd64
pkg: ledger
BenchmarkParseLedger-8   	 300000	      4305 ns/op	    4336 B/op	       6 allocs/op