### PR TITLE
Add support for wildcard includes

### DIFF
--- a/ledgerReader.go
+++ b/ledgerReader.go
@@ -56,7 +56,9 @@ func includeFile(filename string, buf *bytes.Buffer) error {
 				return fmt.Errorf("%s:%d: invalid include directive", filename, lineNum)
 			}
 
-			err := includeFile(filepath.Join(filename, "..", pieces[1]), buf)
+			includedPath := filepath.Join(filename, "..", pieces[1])
+			fmt.Println("Attempting to open " + includedPath)
+			err := includeFile(includedPath, buf)
 			if err != nil {
 				return fmt.Errorf("%s:%d: %s", filename, lineNum, err.Error())
 			}

--- a/ledgerReader.go
+++ b/ledgerReader.go
@@ -20,7 +20,6 @@ func NewLedgerReader(filename string) (*bytes.Buffer, error) {
 	var buf bytes.Buffer
 
 	err := includeFile(filename, &buf)
-	//fmt.Printf("Buffer: %q\n", buf)
 	return &buf, err
 }
 

--- a/ledgerReader_test.go
+++ b/ledgerReader_test.go
@@ -51,6 +51,27 @@ func TestLedgerScannerSingleInclude(t *testing.T) {
 	}
 }
 
+func TestLedgerScannerWildcardInclude(t *testing.T) {
+	r, err := NewLedgerReader("testdata/ledgerReader_input_1_root")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected, _ := ioutil.ReadFile(filepath.Join("testdata", "ledgerReader_expected_1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(parsed, expected) {
+		t.Fatalf("expected:\n%s\n\n got:\n%s", expected, parsed)
+	}
+}
+
 func TestMarkerSplit(t *testing.T) {
 	filename, lineNum := parseMarker(";__ledger_file*-*/somedir/somefile*-*45")
 	if filename != "/somedir/somefile" {

--- a/ledgerReader_test.go
+++ b/ledgerReader_test.go
@@ -52,7 +52,7 @@ func TestLedgerScannerSingleInclude(t *testing.T) {
 }
 
 func TestLedgerScannerWildcardInclude(t *testing.T) {
-	r, err := NewLedgerReader("testdata/ledgerReader_input_1_root")
+	r, err := NewLedgerReader("testdata/ledgerReader_input_wildcard_root")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func TestLedgerScannerWildcardInclude(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected, _ := ioutil.ReadFile(filepath.Join("testdata", "ledgerReader_expected_1"))
+	expected, _ := ioutil.ReadFile(filepath.Join("testdata", "ledgerReader_expected_wildcard"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/parse.go
+++ b/parse.go
@@ -9,8 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/howeyc/ledger/internal/github.com/joyt/godate"
-
+	date "github.com/aThorp96/ledger/internal/github.com/joyt/godate"
 	"github.com/marcmak/calc/calc"
 )
 

--- a/parse.go
+++ b/parse.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	date "github.com/aThorp96/ledger/internal/github.com/joyt/godate"
+	date "github.com/howeyc/ledger/internal/github.com/joyt/godate"
 	"github.com/marcmak/calc/calc"
 )
 

--- a/testdata/ledgerReader_expected_wildcard
+++ b/testdata/ledgerReader_expected_wildcard
@@ -1,0 +1,13 @@
+;__ledger_file*-*testdata/ledgerReader_input_root_wildcard*-*0
+the
+quick
+;__ledger_file*-*testdata/ledgerReader_input_wildcard_1*-*0
+brown
+fox
+jumps
+;__ledger_file*-*testdata/ledgerReader_input_wildcard_2*-*0
+over
+the
+;__ledger_file*-*testdata/ledgerReader_input_1_root*-*3
+lazy
+dog

--- a/testdata/ledgerReader_expected_wildcard
+++ b/testdata/ledgerReader_expected_wildcard
@@ -1,4 +1,4 @@
-;__ledger_file*-*testdata/ledgerReader_input_root_wildcard*-*0
+;__ledger_file*-*testdata/ledgerReader_input_wildcard_root*-*0
 the
 quick
 ;__ledger_file*-*testdata/ledgerReader_input_wildcard_1*-*0
@@ -8,6 +8,6 @@ jumps
 ;__ledger_file*-*testdata/ledgerReader_input_wildcard_2*-*0
 over
 the
-;__ledger_file*-*testdata/ledgerReader_input_1_root*-*3
+;__ledger_file*-*testdata/ledgerReader_input_wildcard_root*-*3
 lazy
 dog

--- a/testdata/ledgerReader_input_wildcard_1
+++ b/testdata/ledgerReader_input_wildcard_1
@@ -1,3 +1,3 @@
+brown
+fox
 jumps
-over
-the

--- a/testdata/ledgerReader_input_wildcard_1
+++ b/testdata/ledgerReader_input_wildcard_1
@@ -1,0 +1,3 @@
+jumps
+over
+the

--- a/testdata/ledgerReader_input_wildcard_2
+++ b/testdata/ledgerReader_input_wildcard_2
@@ -1,3 +1,2 @@
-jumps
 over
 the

--- a/testdata/ledgerReader_input_wildcard_2
+++ b/testdata/ledgerReader_input_wildcard_2
@@ -1,0 +1,3 @@
+jumps
+over
+the

--- a/testdata/ledgerReader_input_wildcard_root
+++ b/testdata/ledgerReader_input_wildcard_root
@@ -1,0 +1,4 @@
+the
+include ledgerReader_input_wildcard*
+lazy
+dog

--- a/testdata/ledgerReader_input_wildcard_root
+++ b/testdata/ledgerReader_input_wildcard_root
@@ -1,4 +1,5 @@
 the
+quick
 include ledgerReader_input_wildcard*
 lazy
 dog


### PR DESCRIPTION
I don't know if this has been discussed before on here. This is a feature that I've become very accustomed to in [ledger](https://github.com/ledger/ledger), and I think is justifiable to include here (no pun intended). 

All that is done to perform the wildcard extension is a call to `filename.Glob`, with each result being included if it has not been already. This results in the wildcard extensions being parsed in alphabetical order and prevents recursive self-inclusion.