### PR TITLE
Improve baysian matching for import

### DIFF
--- a/ledger/cmd/import.go
+++ b/ledger/cmd/import.go
@@ -70,15 +70,19 @@ var importCmd = &cobra.Command{
 		classifier := bayesian.NewClassifier(classes...)
 		for _, tran := range generalLedger {
 			payeeWords := strings.Fields(tran.Payee)
+			// learn accounts names (except matchingAccount) for transactions where matchingAccount is present
 			learnName := false
 			for _, accChange := range tran.AccountChanges {
-				// learn accounts names (except matchingAccount) for transactions where matchingAccount is present
 				if accChange.Name == matchingAccount {
 					learnName = true
-					continue
+					break
 				}
-				if learnName {
-					classifier.Learn(payeeWords, bayesian.Class(accChange.Name))
+			}
+			if learnName {
+				for _, accChange := range tran.AccountChanges {
+					if accChange.Name != matchingAccount {
+						classifier.Learn(payeeWords, bayesian.Class(accChange.Name))
+					}
 				}
 			}
 		}

--- a/ledger/cmd/import.go
+++ b/ledger/cmd/import.go
@@ -70,8 +70,16 @@ var importCmd = &cobra.Command{
 		classifier := bayesian.NewClassifier(classes...)
 		for _, tran := range generalLedger {
 			payeeWords := strings.Fields(tran.Payee)
+			learnName := false
 			for _, accChange := range tran.AccountChanges {
-				classifier.Learn(payeeWords, bayesian.Class(accChange.Name))
+				// learn accounts names (except matchingAccount) for transactions where matchingAccount is present
+				if accChange.Name == matchingAccount {
+					learnName = true
+					continue
+				}
+				if learnName {
+					classifier.Learn(payeeWords, bayesian.Class(accChange.Name))
+				}
 			}
 		}
 
@@ -116,9 +124,6 @@ var importCmd = &cobra.Command{
 					for j, score := range scores {
 						if j == 0 {
 							matchScore = score
-						}
-						if string(classifier.Classes[j]) == csvAccount.Name {
-							continue
 						}
 						if score > matchScore {
 							matchScore = score


### PR DESCRIPTION
I've been finding that when importing multiple accounts to the same Ledger file, I sometimes end up with matches that don't make sense. For example, given these previous transactions:

```
2022/05/25 Gone Bananas
    Assets:Bob                                                         -6.90
    Expenses:Groceries                                                  6.90 

2022/05/30 Gone Bananas
    Assets:Mary                                                     -20.54
    Expenses:Groceries                                               20.54 
```

an import for Mary will sometimes produce a transaction like this:

```
2022/07/14 Gone Bananas
    Assets:Mary                                                     -12.95
    Assets:Bob                                                       12.95
```

The fix in this PR makes it so that when importing for Mary, only previous transactions containing `Assets:Mary` are considered.