### PR TITLE
Import fixes

### DIFF
--- a/ledger/cmd/import.go
+++ b/ledger/cmd/import.go
@@ -53,7 +53,7 @@ var importCmd = &cobra.Command{
 			return
 		}
 		for _, m := range matchingAccounts {
-			if m.Name == accountSubstring {
+			if strings.EqualFold(m.Name, accountSubstring) {
 				matchingAccount = m.Name
 				break
 			}

--- a/ledger/cmd/import.go
+++ b/ledger/cmd/import.go
@@ -52,7 +52,15 @@ var importCmd = &cobra.Command{
 			fmt.Println("Unable to find matching account.")
 			return
 		}
-		matchingAccount = matchingAccounts[len(matchingAccounts)-1].Name
+		for _, m := range matchingAccounts {
+			if m.Name == accountSubstring {
+				matchingAccount = m.Name
+				break
+			}
+		}
+		if matchingAccount == "" {
+			matchingAccount = matchingAccounts[len(matchingAccounts)-1].Name
+		}
 
 		allAccounts := ledger.GetBalances(generalLedger, []string{})
 
@@ -188,7 +196,7 @@ func init() {
 
 func existingTransaction(generalLedger []*ledger.Transaction, transDate time.Time, payee string) bool {
 	for _, trans := range generalLedger {
-		if trans.Date == transDate && trans.Payee == payee {
+		if trans.Date == transDate && strings.TrimSpace(trans.Payee) == strings.TrimSpace(payee) {
 			return true
 		}
 	}


### PR DESCRIPTION
- `matchingAccount` should be set to the account name that exactly matches, otherwise use the last of the prefix matches
- `existingTransaction()` should ignore whitespace at beginning/end of the payee string.