### PR TITLE
Stop erroring if every transaction change is zero

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -96,6 +96,36 @@ var testCases = []testCase{
 		errors.New(":5: Unable to parse transaction: Unable to balance transaction: more than one account empty"),
 	},
 	{
+		"all empty",
+		`1970/01/01 Payee
+	Expense/test
+	Wallet
+	Assets
+	Bank
+`,
+		[]*Transaction{
+			{
+				Payee: "Payee",
+				Date:  time.Unix(0, 0).UTC(),
+				AccountChanges: []Account{
+					{
+						Name: "Expense/test",
+					},
+					{
+						Name: "Wallet",
+					},
+					{
+						Name: "Assets",
+					},
+					{
+						Name: "Bank",
+					},
+				},
+			},
+		},
+		nil,
+	},
+	{
 		"multiple empty lines",
 		`1970/01/01 Payee
 	Expense/test  (123 * 3)


### PR DESCRIPTION
In some situations, there can be a zero-value transaction in the imported CSV files. These are usually for card checks and similar usecases. Prior to this change, the ledger tool would return the `more than one account empty` error in that case.

This change updates the logic to return early if the balances sum to zero. If there is any remaining balance, then the old behaviour is preserved.