### PR TITLE
feat: allow dashes in begin and end dates

### DIFF
--- a/ledger/cmd/print.go
+++ b/ledger/cmd/print.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/howeyc/ledger"
 	"github.com/howeyc/ledger/decimal"
+	date "github.com/joyt/godate"
 	"github.com/spf13/cobra"
 )
 
@@ -34,8 +35,8 @@ func cliTransactions() ([]*ledger.Transaction, error) {
 		columnWidth = 132
 	}
 
-	parsedStartDate, tstartErr := time.Parse(transactionDateFormat, startString)
-	parsedEndDate, tendErr := time.Parse(transactionDateFormat, endString)
+	parsedStartDate, tstartErr := date.Parse(startString)
+	parsedEndDate, tendErr := date.Parse(endString)
 
 	if tstartErr != nil || tendErr != nil {
 		return nil, errors.New("unable to parse start or end date string argument")


### PR DESCRIPTION
This time format was already allowed for entries in the ledger data file, and it was odd to hit time parse errors for dates written in the same format with the -b/--begin-date and -e/--end-date flags.