### PR TITLE
fix: parse decimals without whole portion

### DIFF
--- a/decimal/decimal.go
+++ b/decimal/decimal.go
@@ -84,7 +84,9 @@ func NewFromString(s string) (Decimal, error) {
 	if whole, frac, split := strings.Cut(s, "."); split {
 		var neg bool
 		var w int64
-		if whole != "" {
+		if whole == "-" {
+			neg = true
+		} else if whole != "" {
 			var err error
 			neg, w, err = atoi64(whole)
 			if err != nil {

--- a/decimal/decimal.go
+++ b/decimal/decimal.go
@@ -82,9 +82,14 @@ func atoi64(s string) (bool, int64, error) {
 // error if integer parsing fails.
 func NewFromString(s string) (Decimal, error) {
 	if whole, frac, split := strings.Cut(s, "."); split {
-		neg, w, err := atoi64(whole)
-		if err != nil {
-			return Zero, err
+		var neg bool
+		var w int64
+		if whole != "" {
+			var err error
+			neg, w, err = atoi64(whole)
+			if err != nil {
+				return Zero, err
+			}
 		}
 
 		// overflow
@@ -115,7 +120,7 @@ func NewFromString(s string) (Decimal, error) {
 		if neg {
 			f = -f
 		}
-		return Decimal(w + f), err
+		return Decimal(w + f), nil
 	} else {
 		_, i, err := atoi64(s)
 		if i > parseMax || i < parseMin {

--- a/decimal/decimal_test.go
+++ b/decimal/decimal_test.go
@@ -341,6 +341,11 @@ var testParseCases = []testCase{
 		`atoi failed`,
 		"(123 * 6)",
 	},
+	{
+		"missingwhole",
+		"0.50",
+		".50",
+	},
 }
 
 func TestStringParse(t *testing.T) {

--- a/decimal/decimal_test.go
+++ b/decimal/decimal_test.go
@@ -346,6 +346,11 @@ var testParseCases = []testCase{
 		"0.50",
 		".50",
 	},
+	{
+		"negmissingwhole",
+		"-0.50",
+		"-.50",
+	},
 }
 
 func TestStringParse(t *testing.T) {


### PR DESCRIPTION
When an transaction entry contains a decimal amount with no whole portion specified, assume the whole part is zero.

This avoids creating additional accounts from misparsed transactions, where the account name otherwise contained the decimal portion at the end.